### PR TITLE
pass xml string to "Call SOAP Method With XML" instead of xml file

### DIFF
--- a/SoapLibrary/SoapLibrary.py
+++ b/SoapLibrary/SoapLibrary.py
@@ -62,7 +62,10 @@ class SoapLibrary:
         | ${response}= | Call SOAP Method With XML |  C:\\Request.xml |
         """
         # TODO check with different headers: 'SOAPAction': self.url + '/%s' % method}
-        raw_text_xml = self._convert_xml_to_raw_text(xml)
+        if str(xml).find("<") != -1:
+            raw_text_xml = str(xml)
+        else:
+            raw_text_xml = self._convert_xml_to_raw_text(xml)
         xml_obj = etree.fromstring(raw_text_xml)
         response = self.client.transport.post_xml(address=self.url, envelope=xml_obj, headers=headers)
         etree_response = self._parse_from_unicode(response.text)

--- a/Tests/keyword_tests.robot
+++ b/Tests/keyword_tests.robot
@@ -17,6 +17,14 @@ Test read
     ${result}    Get Data From XML By Tag    ${response}    AddResult
     should be equal    8    ${result}
 
+Test read by xml string
+    Create Soap Client    ${wsdl_calculator}
+    ${xml} =  Parse XML  ${requests_dir}${/}Request_Calculator.xml
+    ${xml_str} =  Element To String  ${xml}
+    ${response}    Call SOAP Method With XML  ${xml_str}
+    ${result}    Get Data From XML By Tag    ${response}    AddResult
+    should be equal    8    ${result}
+
 Test read utf8
     Create Soap Client    ${wsdl_ip_geo}
     ${response}    Call SOAP Method With XML    ${requests_dir}${/}request_ip.xml


### PR DESCRIPTION
I want to pass XML string to the "Call SOAP Method With XML" keyword because I need a different representation of one file in several test cases and scenarios.
Also, I add a test case to test this functionality