### PR TITLE
 Client TLS/SSL certificate (#25) 

### DIFF
--- a/SoapLibrary/SoapLibrary.py
+++ b/SoapLibrary/SoapLibrary.py
@@ -10,7 +10,6 @@ from zeep.transports import Transport
 from zeep.wsdl.utils import etree
 from robot.api import logger
 from robot.api.deco import keyword
-from robot.utils import is_falsy, is_string
 from six import iteritems
 from urllib3.exceptions import InsecureRequestWarning
 from .version import VERSION

--- a/SoapLibrary/SoapLibrary.py
+++ b/SoapLibrary/SoapLibrary.py
@@ -9,6 +9,7 @@ from zeep.transports import Transport
 from zeep.wsdl.utils import etree
 from robot.api import logger
 from robot.api.deco import keyword
+from robot.utils import is_falsy, is_string
 from six import iteritems
 from urllib3.exceptions import InsecureRequestWarning
 from .version import VERSION
@@ -52,7 +53,10 @@ class SoapLibrary:
         """
         self.url = url
         session = Session()
-        session.verify = ssl_verify
+        if is_falsy(ssl_verify):
+            session.verify = False
+        elif is_string(ssl_verify):
+            session.verify = ssl_verify
         session.cert = client_cert_location
         self.client = Client(self.url, transport=Transport(session=session))
         logger.info('Connected to: %s' % self.client.wsdl.location)

--- a/SoapLibrary/SoapLibrary.py
+++ b/SoapLibrary/SoapLibrary.py
@@ -30,21 +30,30 @@ class SoapLibrary:
         self.url = None
 
     @keyword("Create SOAP Client")
-    def create_soap_client(self, url, ssl_verify=True):
+    def create_soap_client(self, url, ssl_verify=True, client_cert_location=None):
         """
-        Loads a WSDL from the given URL and creates a Zeep client.
+        Loads a WSDL from the given ``url`` and creates a Zeep client.
         List all Available operations/methods with INFO log level.
 
-        *Input Arguments:*
-        | *Name* | *Description* |
-        | url | wsdl url |
+        By default, server TLS certificate is validated. You can disable this behavior
+        by setting ``ssl_verify`` to ``False`` (not recommended!).
+        If your host uses a self signed certificate, you can also pass the path of the
+        CA_BUNDLE to ``sll_verify``. Accepted are only X.509 ASCII files (file extension .pem, sometimes .crt).
+        If you have two different files for root and intermediate certificate,
+        you must combine them manually into one.
+
+        If your host requires client certificate based authentication, you can pass the
+        path to your client certificate to the ``client_cert_path`` argument.
 
         *Example:*
-        | Create SOAP Client | http://endpoint.com?wsdl |
+        | Create SOAP Client | http://endpoint.com?wsdl  |
+        | Create SOAP Client | https://endpoint.com?wsdl | ssl_verify=True |
+        | Create SOAP Client | https://endpoint.com?wsdl | client_cert_location=${CURDIR}${/}mycert.pem |
         """
         self.url = url
         session = Session()
         session.verify = ssl_verify
+        session.cert = client_cert_location
         self.client = Client(self.url, transport=Transport(session=session))
         logger.info('Connected to: %s' % self.client.wsdl.location)
         info = self.client.service.__dict__


### PR DESCRIPTION
Hi,

as we discussed in #25, this PR exposes ``session.cert`` to the ``Create SOAP Client`` keyword. This way client certificate based authentication should be possible.

I do not have a client certificate based SOAP service for testing purposes yet. I opened the PR anyway so we could already start the code review.