### PR TITLE
Ability specify whether to call SOAP method using WSDL address or service binding address

### DIFF
--- a/SoapLibrary/SoapLibrary.py
+++ b/SoapLibrary/SoapLibrary.py
@@ -67,7 +67,7 @@ class SoapLibrary:
         logger.info('Available operations: %s' % list(operations))
 
     @keyword("Call SOAP Method With XML")
-    def call_soap_method_xml(self, xml, headers=DEFAULT_HEADERS, status=None):
+    def call_soap_method_xml(self, xml, headers=DEFAULT_HEADERS, status=None, use_binding_address=True):
         """
         Send an XML file as a request to the SOAP client. The path to the Request XML file is required as argument,
         the SOAP method is inside the XML file.
@@ -80,6 +80,7 @@ class SoapLibrary:
         | xml | file path to xml file |
         | headers | dictionary with request headers. Default ``{'Content-Type': 'text/xml; charset=utf-8'}`` |
         | status | optional string: anything |
+        | use_binding_address | use service binding address specified in WSDL |
 
         *Example:*
         | ${response}= | Call SOAP Method With XML |  C:\\Request.xml |
@@ -88,7 +89,10 @@ class SoapLibrary:
         # TODO check with different headers: 'SOAPAction': self.url + '/%s' % method}
         raw_text_xml = self._convert_xml_to_raw_text(xml)
         xml_obj = etree.fromstring(raw_text_xml)
-        response = self.client.transport.post_xml(address=self.client.service._binding_options['address'], envelope=xml_obj, headers=headers)
+        if use_binding_address:
+            response = self.client.transport.post_xml(address=self.client.service._binding_options['address'], envelope=xml_obj, headers=headers)
+        else:
+            response = self.client.transport.post_xml(address=self.url, envelope=xml_obj, headers=headers)
         etree_response = self._parse_from_unicode(response.text)
         logger.debug('URL: %s' % response.url)
         logger.debug(etree.tostring(etree_response, pretty_print=True, encoding='unicode'))


### PR DESCRIPTION
I decided to open a PR after reviewing closed issue #34.

In previous versions, `call_soap_method_xml` used `self.url` as the destination address. This was changed to `self.client.service._binding_options['address']` following issue #34. The change made it impossible to test SOAP services that my organization accesses through internal gateway endpoints where the binding address in the WSDL points to an external service that we cannot use and causes requests to fail.

To keep a convoluted explanation short - we need to call the SOAP method using the url that is initially provided when creating the session rather than the specified address within the WSDL.

I went ahead and added an argument to `call_soap_method_xml` that allows users to specify whether to use the binding address or not. To satisfy issue #34, I let the default be true. I'm assuming most services aren't affected by which address is used, but I wasn't too sure how to decide on the best default value. 

The test suite I'm developing will be much _much_ cleaner if I can keep using SoapLibrary rather than a messy combo of XML library and RequestsLibrary. It would be awesome if we can implement a change - and I think it will benefit others.